### PR TITLE
Fix regex to allow dynamic value from req.query i.e searchTerm

### DIFF
--- a/routes/notes.js
+++ b/routes/notes.js
@@ -56,6 +56,7 @@ router.get("/", (req, res, next) => {
 
   if (searchTerm) {
     // filter.title = { $regex: searchTerm };
+    filter.title = new RegExp(searchTerm, "i")  // <--- using RegExp constructor allows us to dynamically inject variable and have regex still work. 
     filter.$or = [{ "title": { $regex: searchTerm } }, { "content": { $regex: searchTerm } }];
   }
 


### PR DESCRIPTION
Was having an issue for example user type in lady gaga and the result did not come back as using 

/searchTerm/i in regex was not working

fix: use RegExp constructor to be able to inject dynamic variable value without breaking the regex.

ie. new RegExp(searchTerm, "i")